### PR TITLE
Fix security scheme so it authenticates properly

### DIFF
--- a/securitySchemes/oauth_2_0.raml
+++ b/securitySchemes/oauth_2_0.raml
@@ -17,5 +17,5 @@ describedBy:
 settings: 
   authorizationUri: https://accounts.google.com/o/oauth2/auth
   accessTokenUri: https://accounts.google.com/o/oauth2/token
-  authorizationGrants: [ code ]
-  scopes: [ https//www.googleapis.com/auth/prediction , https//www.googleapis.com/auth/devstorage.full_control ]
+  authorizationGrants: [ token ]
+  scopes: [ 'https://www.googleapis.com/auth/prediction' , 'https://www.googleapis.com/auth/devstorage.full_control' ]


### PR DESCRIPTION
At least in my usage, these fixes were needed to allow obtaining an access token without an error being returned from Google about invalid scopes, and to allow sending the access token in the Authorization header.